### PR TITLE
OneDriveService: Uploading large files

### DIFF
--- a/onedrive_service/tests/test_util.py
+++ b/onedrive_service/tests/test_util.py
@@ -2,10 +2,12 @@
 # pylint: disable=protected-access
 # pylint: disable=no-self-use
 # pylint: disable=too-few-public-methods
+# pylint: disable=invalid-name
 
 import mock
 
 from onedrive_service.util import OneDriveUtil
+from onedrivesdk.options import HeaderOption
 
 
 class TestOneDriveUtil(object):
@@ -36,3 +38,75 @@ class TestOneDriveUtil(object):
         relative_path = ''
         full_path = od_util._get_full_path(relative_path)
         assert full_path == '/drive/root:/'
+
+    def test_init_upload_session_header_0(self):
+        """
+        Test for _init_upload_session_header
+        start from 0
+        :return:
+        """
+        client = mock.Mock()
+        od_util = OneDriveUtil(client)
+
+        first_range = 0
+        data_len = 100
+        total = 1024
+
+        expected_content = {'Content-Range': 'bytes 0-99/1024',
+                            'Content-Length': 100}
+
+        options = od_util._init_upload_session_header(first_range,
+                                                      data_len, total)
+
+        for option in options:
+            assert isinstance(option, HeaderOption)
+            assert option.key in expected_content
+            assert option.value == expected_content[option.key]
+
+    def test_init_upload_session_header_1000(self):
+        """
+        Test for _init_upload_session_header
+        start from 1000
+        :return:
+        """
+        client = mock.Mock()
+        od_util = OneDriveUtil(client)
+
+        first_range = 1000
+        data_len = 24
+        total = 1024
+
+        expected_content = {'Content-Range': 'bytes 1000-1023/1024',
+                            'Content-Length': 24}
+
+        options = od_util._init_upload_session_header(first_range,
+                                                      data_len, total)
+
+        for option in options:
+            assert isinstance(option, HeaderOption)
+            assert option.key in expected_content
+            assert option.value == expected_content[option.key]
+
+    def test_init_upload_session_header_100(self):
+        """
+        Test for _init_upload_session_header
+        start from 100
+        :return:
+        """
+        client = mock.Mock()
+        od_util = OneDriveUtil(client)
+
+        first_range = 100
+        data_len = 100
+        total = 1024
+
+        expected_content = {'Content-Range': 'bytes 100-199/1024',
+                            'Content-Length': 100}
+
+        options = od_util._init_upload_session_header(first_range,
+                                                      data_len, total)
+
+        for option in options:
+            assert isinstance(option, HeaderOption)
+            assert option.key in expected_content
+            assert option.value == expected_content[option.key]


### PR DESCRIPTION
How to use ex:
    onedrive_client = authenticate()
    service = OneDriveUtil(onedrive_client)

    onedrive_file_name = 'maestro-cli.zip'
    onedrive_full_path = '/Images/maestro-cli.zip'
    session = service.create_upload_session(onedrive_file_name,
                                            onedrive_full_path)

    local_file_to_upload = './maestro-cli.zip'
    total_size = os.path.getsize(local_file_to_upload)
    with open(local_file_to_upload) as fd:
        # recommended chunk size is between 5-10 MiB
        # chunk in 1 MiB
        chunk_size = 1 * 1024 * 1024
        data = fd.read(chunk_size)
        while data:
            if data:
                status = service.upload_session_status(session.upload_url)
                # get next start value
                next_range = status.next_expected_ranges[0].split('-')[0]
                service.upload_session(session.upload_url, data,
                                       int(total_size),
                                       int(next_range))

            data = fd.read(chunk_size)